### PR TITLE
Fix: Use Mass-Assignment

### DIFF
--- a/app/Console/Commands/MakeRepositoryCommand.php
+++ b/app/Console/Commands/MakeRepositoryCommand.php
@@ -89,8 +89,10 @@ class MakeRepositoryCommand extends Command
             }
         
             public function update(\$id, \$opts = []) {
-                \$this->model()->where('id', \$id)->update(\$opts);
-                return \$this->single(\$id);
+                \$item = \$this->model()->findOrFail(\$id);
+                \$item->fill(\$opts);
+                \$item->save();
+                return \$item;
             }
         
             public function count(${name}Filters \$filters)

--- a/app/Http/Requests/ContentRequest.php
+++ b/app/Http/Requests/ContentRequest.php
@@ -33,9 +33,7 @@ class ContentRequest extends FormRequest
         return [
             'owner_id' => 'required|numeric',
             'content_type_id' => 'required|numeric|exists:content_types,id',
-            'value' => 'required|string',
-            'created_at' => [ new AbsentRule() ],
-            'updated_at' => [ new AbsentRule() ]
+            'value' => 'required|string'
         ];
     }
 }

--- a/app/Http/Requests/ContentTypeRequest.php
+++ b/app/Http/Requests/ContentTypeRequest.php
@@ -34,9 +34,7 @@ class ContentTypeRequest extends FormRequest
             'type' => 'required|string',
             'name' => 'required|string',
             'display_name' => 'required|string',
-            'school_id' => [ new AbsentRule() ],
-            'created_at' => [ new AbsentRule() ],
-            'updated_at' => [ new AbsentRule() ]
+            'school_id' => [ new AbsentRule() ]
         ];
     }
 }

--- a/app/Http/Requests/RoleRequest.php
+++ b/app/Http/Requests/RoleRequest.php
@@ -28,9 +28,7 @@ class RoleRequest extends FormRequest
     {
         return [
             'name' => 'required|string',
-            'display_name' => 'required|string',
-            'created_at' => [ new AbsentRule() ],
-            'updated_at' => [ new AbsentRule() ]
+            'display_name' => 'required|string'
         ];
     }
 }

--- a/app/Http/Requests/UserHasRoleRequest.php
+++ b/app/Http/Requests/UserHasRoleRequest.php
@@ -34,9 +34,7 @@ class UserHasRoleRequest extends FormRequest
         return [
             'user_id' => 'required|numeric|exists:users,id',
             'role_id' => 'required|numeric|exists:roles,id',
-            'school_id' => 'numeric|exists:schools,id',
-            'created_at' => [ new AbsentRule() ],
-            'updated_at' => [ new AbsentRule() ]
+            'school_id' => 'numeric|exists:schools,id'
         ];
     }
 }

--- a/app/Repositories/ChargeableRepository.php
+++ b/app/Repositories/ChargeableRepository.php
@@ -39,8 +39,10 @@ class ChargeableRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(ChargeableFilters $filters)

--- a/app/Repositories/ChargeableServiceRepository.php
+++ b/app/Repositories/ChargeableServiceRepository.php
@@ -39,8 +39,10 @@ class ChargeableServiceRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(ChargeableServiceFilters $filters)

--- a/app/Repositories/ContentRepository.php
+++ b/app/Repositories/ContentRepository.php
@@ -35,8 +35,10 @@ class ContentRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(ContentFilters $filters)

--- a/app/Repositories/ContentTypeRepository.php
+++ b/app/Repositories/ContentTypeRepository.php
@@ -35,8 +35,10 @@ class ContentTypeRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(ContentTypeFilters $filters)

--- a/app/Repositories/CourseDependencyRepository.php
+++ b/app/Repositories/CourseDependencyRepository.php
@@ -39,8 +39,10 @@ class CourseDependencyRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(CourseDependencyFilters $filters)

--- a/app/Repositories/CourseRepository.php
+++ b/app/Repositories/CourseRepository.php
@@ -39,8 +39,10 @@ class CourseRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->course($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(CourseFilters $filters)

--- a/app/Repositories/DepartmentRepository.php
+++ b/app/Repositories/DepartmentRepository.php
@@ -39,8 +39,10 @@ class DepartmentRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->department($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count()

--- a/app/Repositories/FacultyRepository.php
+++ b/app/Repositories/FacultyRepository.php
@@ -39,8 +39,10 @@ class FacultyRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->faculty($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count()

--- a/app/Repositories/GradeRepository.php
+++ b/app/Repositories/GradeRepository.php
@@ -39,8 +39,10 @@ class GradeRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(GradeFilters $filters)

--- a/app/Repositories/GradeTypeRepository.php
+++ b/app/Repositories/GradeTypeRepository.php
@@ -39,8 +39,10 @@ class GradeTypeRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(GradeTypeFilters $filters)

--- a/app/Repositories/ImageRepository.php
+++ b/app/Repositories/ImageRepository.php
@@ -39,8 +39,10 @@ class ImageRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(ImageFilters $filters)

--- a/app/Repositories/ImageTypeRepository.php
+++ b/app/Repositories/ImageTypeRepository.php
@@ -39,8 +39,10 @@ class ImageTypeRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(ImageTypeFilters $filters)

--- a/app/Repositories/IntentRepository.php
+++ b/app/Repositories/IntentRepository.php
@@ -35,8 +35,10 @@ class IntentRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(IntentFilters $filters)

--- a/app/Repositories/IntentTypeRepository.php
+++ b/app/Repositories/IntentTypeRepository.php
@@ -35,8 +35,10 @@ class IntentTypeRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(IntentTypeFilters $filters)

--- a/app/Repositories/LevelRepository.php
+++ b/app/Repositories/LevelRepository.php
@@ -39,8 +39,10 @@ class LevelRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->level($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(LevelFilters $filters)

--- a/app/Repositories/PayableRepository.php
+++ b/app/Repositories/PayableRepository.php
@@ -39,7 +39,7 @@ class PayableRepository
     }
 
     public function update($id, $opts = []) {
-        $payable = $this->model()->where('id', $id)->first();
+        $payable = $this->model()->findOrFail($id);
         if (isset($opts['is_paid'])) $payable->is_paid = $opts['is_paid'];
         $payable->save();
         return $payable;

--- a/app/Repositories/ProgramCreditRepository.php
+++ b/app/Repositories/ProgramCreditRepository.php
@@ -39,8 +39,10 @@ class ProgramCreditRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(ProgramCreditFilters $filters)

--- a/app/Repositories/ProgramRepository.php
+++ b/app/Repositories/ProgramRepository.php
@@ -39,8 +39,10 @@ class ProgramRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->program($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(ProgramFilters $filters)

--- a/app/Repositories/RoleRepository.php
+++ b/app/Repositories/RoleRepository.php
@@ -35,8 +35,10 @@ class RoleRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(RoleFilters $filters)

--- a/app/Repositories/SchoolRepository.php
+++ b/app/Repositories/SchoolRepository.php
@@ -39,8 +39,10 @@ class SchoolRepository
     }
 
     public function update(User $user, $id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->school($user, $id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count()

--- a/app/Repositories/SemesterRepository.php
+++ b/app/Repositories/SemesterRepository.php
@@ -39,8 +39,10 @@ class SemesterRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->semester($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(SemesterFilters $filters)

--- a/app/Repositories/SemesterTypeRepository.php
+++ b/app/Repositories/SemesterTypeRepository.php
@@ -39,8 +39,10 @@ class SemesterTypeRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->type($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(SemesterTypeFilters $filters)

--- a/app/Repositories/SessionRepository.php
+++ b/app/Repositories/SessionRepository.php
@@ -39,8 +39,10 @@ class SessionRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->session($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(SessionFilters $filters)

--- a/app/Repositories/StaffRepository.php
+++ b/app/Repositories/StaffRepository.php
@@ -40,8 +40,10 @@ class StaffRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(StaffFilters $filters)

--- a/app/Repositories/StaffTeachCourseRepository.php
+++ b/app/Repositories/StaffTeachCourseRepository.php
@@ -39,8 +39,10 @@ class StaffTeachCourseRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(StaffTeachCourseFilters $filters)

--- a/app/Repositories/StudentRepository.php
+++ b/app/Repositories/StudentRepository.php
@@ -40,8 +40,10 @@ class StudentRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->student($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(StudentFilters $filters)

--- a/app/Repositories/StudentTakesCourseRepository.php
+++ b/app/Repositories/StudentTakesCourseRepository.php
@@ -39,8 +39,10 @@ class StudentTakesCourseRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(StudentTakesCourseFilters $filters)

--- a/app/Repositories/UserHasRoleRepository.php
+++ b/app/Repositories/UserHasRoleRepository.php
@@ -35,8 +35,10 @@ class UserHasRoleRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->single($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(UserHasRoleFilters $filters)

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -43,8 +43,10 @@ class UserRepository
     }
 
     public function update($id, $opts = []) {
-        $this->model()->where('id', $id)->update($opts);
-        return $this->user($id);
+        $item = $this->model()->findOrFail($id);
+        $item->fill($opts);
+        $item->save();
+        return $item;
     }
 
     public function count(UserFilters $filters)

--- a/app/Services/ContentService.php
+++ b/app/Services/ContentService.php
@@ -17,9 +17,7 @@ class ContentService
         request()->validate([
             'value' => 'string',
             'owner_id' => [ new AbsentRule() ],
-            'content_type_id' => [ new AbsentRule() ],
-            'created_at' => [ new AbsentRule() ],
-            'updated_at' => [ new AbsentRule() ]
+            'content_type_id' => [ new AbsentRule() ]
         ]);
 
         return $this->repo()->update($id, $opts);

--- a/app/Services/ContentTypeService.php
+++ b/app/Services/ContentTypeService.php
@@ -18,9 +18,7 @@ class ContentTypeService
             'name' => 'string', 
             'display_name' => 'string',
             'type' => [ new AbsentRule() ],
-            'school_id' => [ new AbsentRule() ],
-            'created_at' => [ new AbsentRule() ],
-            'updated_at' => [ new AbsentRule() ]
+            'school_id' => [ new AbsentRule() ]
         ]);
 
         return $this->repo()->update($id, $opts);

--- a/app/Services/RoleService.php
+++ b/app/Services/RoleService.php
@@ -17,9 +17,7 @@ class RoleService
     public function update($id, $opts = []) {
         request()->validate([
             'name' => 'string',
-            'display_name' => 'string',
-            'created_at' => [ new AbsentRule() ],
-            'updated_at' => [ new AbsentRule() ]
+            'display_name' => 'string'
         ]);
 
         return $this->repo()->update($id, $opts);

--- a/app/Services/UserHasRoleService.php
+++ b/app/Services/UserHasRoleService.php
@@ -17,9 +17,7 @@ class UserHasRoleService
         request()->validate([
             'user_id' => 'numeric|exists:users,id',
             'role_id' => 'numeric|exists:roles,id',
-            'school_id' => 'numeric|exists:schools,id',
-            'created_at' => [ new AbsentRule() ],
-            'updated_at' => [ new AbsentRule() ]
+            'school_id' => 'numeric|exists:schools,id'
         ]);
 
         return $this->repo()->update($id, $opts);


### PR DESCRIPTION
Use mass-assignment `->fill(...)` method in Repository update methods to prevent timestamp fields in request body from making their way to the Database. Thanks @shalvah @mojoblanco