### PR TITLE
Feat: Email Verification

### DIFF
--- a/app/Filters/UserFilters.php
+++ b/app/Filters/UserFilters.php
@@ -25,8 +25,12 @@ class UserFilters extends BaseFilters
         return $this->builder->with('students');
     }
 
-    public function global():array
-	{
-        return [];
+    public function email_verified():Builder 
+    {
+        return $this->builder->whereHas('contents', function ($q) {
+            return $q->whereHas('type', function ($q) {
+                return $q->where('name', 'email_verified')->where('contents.value', 'true');
+            });
+        });
     }
 }

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -104,13 +104,7 @@ class AuthController extends ApiController
         if ($payload->get('aud') !== UserService::AUD_VERIFICATION) {
             throw new TokenInvalidException();
         }
-        $content_type_id = ContentType::where('name', 'email_verified')->first()->id;
-        if (!$user->contents()->where('content_type_id', $content_type_id)->exists()) {
-            $user->contents()->create([
-                'content_type_id' => $content_type_id,
-                'value' => true
-            ]);
-        }
+        $user->createContent('email_verified', true);
         return redirect('/');
     }
 

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -72,7 +72,7 @@ class UserController extends ApiController
      * Supply User information to create a new one
      */
     public function store(UserRequest $request) {
-        $user = $this->service()->repo()->create($request->all());
+        $user = $this->service()->create($request->all());
         return $this->created($user);
     }
 

--- a/app/Http/Middleware/AccessTokenSecurity.php
+++ b/app/Http/Middleware/AccessTokenSecurity.php
@@ -3,6 +3,7 @@
 use CollegePortal\Models\User;
 use Auth;
 use Closure;
+use App\Services\UserService;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Guard;
 use Tymon\JWTAuth\JWTAuth;
@@ -40,7 +41,7 @@ class AccessTokenSecurity
                     $payload = $jwt_auth->getPayload();
                     $jwt_auth->authenticate();
                     // make sure the token's aud is "access"
-                    if ($payload->get('aud') !== 'access') {
+                    if ($payload->get('aud') !== UserService::AUD_ACCESS) {
                         throw new TokenInvalidException();
                     }
                 }

--- a/app/Http/Middleware/UseTransaction.php
+++ b/app/Http/Middleware/UseTransaction.php
@@ -5,15 +5,11 @@ use Auth;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Guard;
-use Tymon\JWTAuth\JWTAuth;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Illuminate\Support\Facades\DB;
 
 /**
- * makes sure the "db:level" header is present
- * and that it contains "transaction"
+ * makes sure the "db" header is present, and 
+ * that it contains "transaction" as its value
  */
 
 class UseTransaction

--- a/app/Mail/UserVerificationMail.php
+++ b/app/Mail/UserVerificationMail.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class UserVerificationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $data;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $subject = 'Verify your Email';
+
+        return $this->markdown('emails.verification')
+            ->subject($subject)
+            ->with(['name' => $this->data['name'], 'link'=>$this->data['link']]);
+    }
+
+}

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -30,8 +30,13 @@ class UserRepository
         return $filters ? $filters->transform($q->findOrFail($id)) : $q->findOrFail($id);
     }
 
-    public function userByEmail(string $email) {
-        return $this->model()->where('email', $email)->first();
+    public function userByEmail(string $email, UserFilters $filters = null) {
+        $q = $this->model();
+        if ($filters) {
+            $q = $q->filter($filters);
+        }
+        $user = $q->where('email', $email)->first();
+        return $filters ? $filters->transform($user) : $user;
     }
 
     public function delete($id) {

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -13,6 +13,10 @@ use Carbon\Carbon;
 
 class UserService extends BaseService
 {
+    public const AUD_RESEND_VERIFICATION = "resend-verification";
+    public const AUD_VERIFICATION = "verification";
+    public const AUD_ACCESS = "access";
+
     protected $intentService;
 
     public function __construct(IntentService $intentService) {
@@ -57,9 +61,9 @@ class UserService extends BaseService
 
     public function sendVerificationMail(User $user) {
         //create jwt with aud to prevent interferance with authentication
-        $payload = JWTFactory::sub($user->id)->aud('verification')->ttl(null)->make();
+        $payload = JWTFactory::sub($user->id)->aud(self::AUD_VERIFICATION)->ttl(null)->make();
         $token = JWTAuth::encode($payload)->get();
-        $link = url("/auth/verify?t={$token}");
+        $link = url("/api/v1/auth/verify?t={$token}");
         Mail::to($user->email)->send(new UserVerificationMail(['name' => $user->display_name, 'link' => $link]));
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -64,12 +64,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/college-portal/api-models.git",
-                "reference": "1e837011b8dd93867a16aa290f1e4b46bbfc9057"
+                "reference": "3790ab15d714e5d9485cdfa5e9d9506cf4012fe1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/college-portal/api-models/zipball/1e837011b8dd93867a16aa290f1e4b46bbfc9057",
-                "reference": "1e837011b8dd93867a16aa290f1e4b46bbfc9057",
+                "url": "https://api.github.com/repos/college-portal/api-models/zipball/3790ab15d714e5d9485cdfa5e9d9506cf4012fe1",
+                "reference": "3790ab15d714e5d9485cdfa5e9d9506cf4012fe1",
                 "shasum": ""
             },
             "require": {
@@ -102,7 +102,7 @@
                 }
             ],
             "description": "Models for Database Tables and Views for the College-Portal project",
-            "time": "2018-08-13T08:26:40+00:00"
+            "time": "2018-08-25T14:54:37+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",

--- a/composer.lock
+++ b/composer.lock
@@ -64,12 +64,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/college-portal/api-models.git",
-                "reference": "f81a72198fdc4c763166f2e9d65650c5efdd67cc"
+                "reference": "1e837011b8dd93867a16aa290f1e4b46bbfc9057"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/college-portal/api-models/zipball/f81a72198fdc4c763166f2e9d65650c5efdd67cc",
-                "reference": "f81a72198fdc4c763166f2e9d65650c5efdd67cc",
+                "url": "https://api.github.com/repos/college-portal/api-models/zipball/1e837011b8dd93867a16aa290f1e4b46bbfc9057",
+                "reference": "1e837011b8dd93867a16aa290f1e4b46bbfc9057",
                 "shasum": ""
             },
             "require": {
@@ -102,7 +102,7 @@
                 }
             ],
             "description": "Models for Database Tables and Views for the College-Portal project",
-            "time": "2018-08-13T08:18:35+00:00"
+            "time": "2018-08-13T08:26:40+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -139,16 +139,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.7.1",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a"
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/b3217d58609e9c8e661cd41357a54d926c4a2a1a",
-                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57",
                 "shasum": ""
             },
             "require": {
@@ -159,8 +159,9 @@
             },
             "require-dev": {
                 "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^4.0",
                 "mongodb/mongodb": "^1.1",
-                "phpunit/phpunit": "^5.7",
+                "phpunit/phpunit": "^7.0",
                 "predis/predis": "~1.0"
             },
             "suggest": {
@@ -169,7 +170,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -204,12 +205,12 @@
                 }
             ],
             "description": "Caching library offering an object-oriented API for many cache backends",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org",
             "keywords": [
                 "cache",
                 "caching"
             ],
-            "time": "2017-08-25T07:02:50+00:00"
+            "time": "2018-08-21T18:01:43+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -536,16 +537,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.4",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "8790f594151ca6a2010c6218e09d96df67173ad3"
+                "reference": "54859fabea8b3beecbb1a282888d5c990036b9e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/8790f594151ca6a2010c6218e09d96df67173ad3",
-                "reference": "8790f594151ca6a2010c6218e09d96df67173ad3",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/54859fabea8b3beecbb1a282888d5c990036b9e3",
+                "reference": "54859fabea8b3beecbb1a282888d5c990036b9e3",
                 "shasum": ""
             },
             "require": {
@@ -589,7 +590,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2018-04-10T10:11:19+00:00"
+            "time": "2018-08-16T20:49:45+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -1072,16 +1073,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.6.33",
+            "version": "v5.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "8a708b989adc320c451ee639d812af81f884666b"
+                "reference": "66c9cf8119b422b71273271db1f12e20d74ad49b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/8a708b989adc320c451ee639d812af81f884666b",
-                "reference": "8a708b989adc320c451ee639d812af81f884666b",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/66c9cf8119b422b71273271db1f12e20d74ad49b",
+                "reference": "66c9cf8119b422b71273271db1f12e20d74ad49b",
                 "shasum": ""
             },
             "require": {
@@ -1207,20 +1208,20 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2018-08-09T20:36:39+00:00"
+            "time": "2018-08-21T13:44:37+00:00"
         },
         {
             "name": "laravel/socialite",
-            "version": "v3.0.12",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/socialite.git",
-                "reference": "b5f465847b1d637efa86bbfe2fc1c9d2bd12f60f"
+                "reference": "65f771ff4f266ebae23de1a3f18efd80a1da2f8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/socialite/zipball/b5f465847b1d637efa86bbfe2fc1c9d2bd12f60f",
-                "reference": "b5f465847b1d637efa86bbfe2fc1c9d2bd12f60f",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/65f771ff4f266ebae23de1a3f18efd80a1da2f8d",
+                "reference": "65f771ff4f266ebae23de1a3f18efd80a1da2f8d",
                 "shasum": ""
             },
             "require": {
@@ -1229,7 +1230,7 @@
                 "illuminate/http": "~5.4",
                 "illuminate/support": "~5.4",
                 "league/oauth1-client": "~1.0",
-                "php": ">=5.4.0"
+                "php": ">=5.6.4"
             },
             "require-dev": {
                 "mockery/mockery": "~0.9",
@@ -1265,11 +1266,12 @@
                 }
             ],
             "description": "Laravel wrapper around OAuth 1 & OAuth 2 libraries.",
+            "homepage": "https://laravel.com",
             "keywords": [
                 "laravel",
                 "oauth"
             ],
-            "time": "2018-06-01T15:06:47+00:00"
+            "time": "2018-08-16T12:51:21+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -1336,16 +1338,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.45",
+            "version": "1.0.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "a99f94e63b512d75f851b181afcdf0ee9ebef7e6"
+                "reference": "f3e0d925c18b92cf3ce84ea5cc58d62a1762a2b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a99f94e63b512d75f851b181afcdf0ee9ebef7e6",
-                "reference": "a99f94e63b512d75f851b181afcdf0ee9ebef7e6",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f3e0d925c18b92cf3ce84ea5cc58d62a1762a2b2",
+                "reference": "f3e0d925c18b92cf3ce84ea5cc58d62a1762a2b2",
                 "shasum": ""
             },
             "require": {
@@ -1357,7 +1359,7 @@
             "require-dev": {
                 "ext-fileinfo": "*",
                 "phpspec/phpspec": "^3.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^5.7.10"
             },
             "suggest": {
                 "ext-fileinfo": "Required for MimeType",
@@ -1416,7 +1418,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2018-05-07T08:44:23+00:00"
+            "time": "2018-08-22T07:45:22+00:00"
         },
         {
             "name": "league/oauth1-client",
@@ -1795,12 +1797,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mykeels/laravel-filters.git",
-                "reference": "844c9c7eee2dae70bb12901506f6f8ffbf953509"
+                "reference": "de09409f7f5585041232217a6bd7570bee05b1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mykeels/laravel-filters/zipball/844c9c7eee2dae70bb12901506f6f8ffbf953509",
-                "reference": "844c9c7eee2dae70bb12901506f6f8ffbf953509",
+                "url": "https://api.github.com/repos/mykeels/laravel-filters/zipball/de09409f7f5585041232217a6bd7570bee05b1a5",
+                "reference": "de09409f7f5585041232217a6bd7570bee05b1a5",
                 "shasum": ""
             },
             "require": {
@@ -1834,7 +1836,7 @@
                 }
             ],
             "description": "Provides a composable interface for data filtering with query strings",
-            "time": "2018-08-14T19:37:12+00:00"
+            "time": "2018-08-14T19:54:31+00:00"
         },
         {
             "name": "namshi/jose",
@@ -4078,58 +4080,6 @@
             "time": "2017-07-17T17:39:19+00:00"
         },
         {
-            "name": "evert/phpdoc-md",
-            "version": "0.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/evert/phpdoc-md.git",
-                "reference": "afa89bd55de9d27abcfebaf3a3c0097f7590dd11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/evert/phpdoc-md/zipball/afa89bd55de9d27abcfebaf3a3c0097f7590dd11",
-                "reference": "afa89bd55de9d27abcfebaf3a3c0097f7590dd11",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.1",
-                "twig/twig": "~1.2|2.0"
-            },
-            "require-dev": {
-                "phpdocumentor/phpdocumentor": "~2.8.0",
-                "sabre/cs": "~0.0.5"
-            },
-            "bin": [
-                "bin/phpdocmd"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPDocMD\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Evert Pot",
-                    "email": "evert@rooftopsolutions.nl",
-                    "homepage": "http://www.rooftopsolutions.nl/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "PHP documentation generator, with markdown output",
-            "homepage": "https://github.com/evert/phpdoc-md",
-            "keywords": [
-                "markdown",
-                "php",
-                "phpdoc"
-            ],
-            "time": "2016-02-11T22:08:37+00:00"
-        },
-        {
             "name": "filp/whoops",
             "version": "2.2.0",
             "source": {
@@ -5081,16 +5031,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.3.1",
+            "version": "7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f9b14c17860eccb440a0352a117a81eb754cff5a"
+                "reference": "34705f81bddc3f505b9599a2ef96e2b4315ba9b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f9b14c17860eccb440a0352a117a81eb754cff5a",
-                "reference": "f9b14c17860eccb440a0352a117a81eb754cff5a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/34705f81bddc3f505b9599a2ef96e2b4315ba9b8",
+                "reference": "34705f81bddc3f505b9599a2ef96e2b4315ba9b8",
                 "shasum": ""
             },
             "require": {
@@ -5161,7 +5111,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-08-07T06:44:28+00:00"
+            "time": "2018-08-22T06:39:21+00:00"
         },
         {
             "name": "react/event-loop",
@@ -5957,72 +5907,6 @@
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "time": "2017-04-07T12:08:54+00:00"
-        },
-        {
-            "name": "twig/twig",
-            "version": "v1.35.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/twigphp/Twig.git",
-                "reference": "7e081e98378a1e78c29cc9eba4aefa5d78a05d2a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/7e081e98378a1e78c29cc9eba4aefa5d78a05d2a",
-                "reference": "7e081e98378a1e78c29cc9eba4aefa5d78a05d2a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "require-dev": {
-                "psr/container": "^1.0",
-                "symfony/debug": "^2.7",
-                "symfony/phpunit-bridge": "^3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.35-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
-                },
-                "psr-4": {
-                    "Twig\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
-                    "name": "Armin Ronacher",
-                    "email": "armin.ronacher@active-4.com",
-                    "role": "Project Founder"
-                },
-                {
-                    "name": "Twig Team",
-                    "homepage": "https://twig.symfony.com/contributors",
-                    "role": "Contributors"
-                }
-            ],
-            "description": "Twig, the flexible, fast, and secure template language for PHP",
-            "homepage": "https://twig.symfony.com",
-            "keywords": [
-                "templating"
-            ],
-            "time": "2018-07-13T07:12:17+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -1795,12 +1795,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mykeels/laravel-filters.git",
-                "reference": "a90bc9b89c293ea7747650ff617159eaae37de4c"
+                "reference": "844c9c7eee2dae70bb12901506f6f8ffbf953509"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mykeels/laravel-filters/zipball/a90bc9b89c293ea7747650ff617159eaae37de4c",
-                "reference": "a90bc9b89c293ea7747650ff617159eaae37de4c",
+                "url": "https://api.github.com/repos/mykeels/laravel-filters/zipball/844c9c7eee2dae70bb12901506f6f8ffbf953509",
+                "reference": "844c9c7eee2dae70bb12901506f6f8ffbf953509",
                 "shasum": ""
             },
             "require": {
@@ -1809,6 +1809,7 @@
                 "illuminate/support": "^5.6"
             },
             "require-dev": {
+                "phpstan/phpstan": "^0.10.3",
                 "squizlabs/php_codesniffer": "^3.3"
             },
             "type": "library",
@@ -1833,7 +1834,7 @@
                 }
             ],
             "description": "Provides a composable interface for data filtering with query strings",
-            "time": "2018-08-06T23:24:58+00:00"
+            "time": "2018-08-14T19:37:12+00:00"
         },
         {
             "name": "namshi/jose",

--- a/database/seeds/ContentTypesTableSeeder.php
+++ b/database/seeds/ContentTypesTableSeeder.php
@@ -40,8 +40,8 @@ class ContentTypesTableSeeder extends Seeder
                 'format' => ContentType::OBJECT,
                 'children' => new Collection([
                     [
-                        'name' => 'email_validated',
-                        'display_name' => 'Email Validated',
+                        'name' => 'email_verified',
+                        'display_name' => 'Email Verified',
                         'type' => User::class,
                         'format' => ContentType::BOOLEAN
                     ]

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -36,6 +36,8 @@ use Illuminate\Support\Collection;
 
 class DatabaseSeeder extends Seeder
 {
+    const EMAIL = 'mykeels@mailinator.com';
+
     public function run()
     {
         $this->call(RolesTableSeeder::class);
@@ -44,10 +46,10 @@ class DatabaseSeeder extends Seeder
     }
 
     public function createSchoolOwner() {
-        $user = User::where('email', 'owner.orlando@mailinator.com')->exists() ? $this->createUser() : $this->createUser([
+        $user = User::where('email', EMAIL)->exists() ? $this->createUser() : $this->createUser([
             'first_name' => 'Owner',
             'last_name' => 'Orlando',
-            'email' => 'owner.orlando@mailinator.com'
+            'email' => EMAIL
         ]);
 
         $this->addRole($user, 'admin');

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -46,10 +46,10 @@ class DatabaseSeeder extends Seeder
     }
 
     public function createSchoolOwner() {
-        $user = User::where('email', EMAIL)->exists() ? $this->createUser() : $this->createUser([
+        $user = User::where('email', self::EMAIL)->exists() ? $this->createUser() : $this->createUser([
             'first_name' => 'Owner',
             'last_name' => 'Orlando',
-            'email' => EMAIL
+            'email' => self::EMAIL
         ]);
 
         $this->addRole($user, 'admin');

--- a/resources/views/emails/verification.blade.php
+++ b/resources/views/emails/verification.blade.php
@@ -1,0 +1,17 @@
+@component('mail::message')
+
+<h4>
+    Hello, {{ $name }}
+</h4>
+
+<p>
+    We are excited to have you with us. Could you please verify your email address?
+</p>
+
+@component('mail::button', ['url' => $link])
+Verify
+@endcomponent
+
+Thanks,<br>
+{{ config('app.name') }}
+@endcomponent

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,6 +59,7 @@ Route::group([
 
     Route::post('auth', AuthController::method('login'));
     Route::post('auth/refresh', AuthController::method('refresh'));
+    Route::get('auth/verify', AuthController::method('verify'));
     Route::post('auth/resend', AuthController::method('resendVerificationMail'));
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,6 +59,7 @@ Route::group([
 
     Route::post('auth', AuthController::method('login'));
     Route::post('auth/refresh', AuthController::method('refresh'));
+    Route::post('auth/resend', AuthController::method('resendVerificationMail'));
 
     /**
      * auth routes

--- a/routes/api.php
+++ b/routes/api.php
@@ -74,7 +74,9 @@ Route::group([
         
         Route::resource('/schools', SchoolController::class(), $excepts);
         
-        Route::resource('/users', UserController::class(), $excepts);
+        Route::resource('/users', UserController::class(), array_merge($excepts, [ 'store' ]));
+
+        Route::post('/users', AuthController::method('store'))->middleware('throttle:10');  
         
         Route::resource('/faculties', FacultyController::class(), $excepts);
         

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -50,10 +50,24 @@ class AuthTest extends TestCase
             'password' => $password
         ]);
 
-        $response->assertStatus(200);
+        // should FAIL because email is not verified
+        $response->assertStatus(403);
 
         $response->assertJsonStructure([
             'token'
+        ]);
+        
+        // attempt email verification
+        $token = $response->baseResponse->original['token'];
+
+        $response = $this->post($this->url('auth/resend'), [], [
+            'HTTP_Authorization' => "Bearer $token"
+        ]);
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'message' => 'verification mail sent'
         ]);
     }
 


### PR DESCRIPTION
Fixes #48 

- User gets an email for verification immediately after registration
- The email contains a link that saves the verification status in the user's content under type `email_verification`
- If the user attempts login before verification status is set, a 403 forbidden response is given, with a token that can be used to re-attempt sending the verification email.
- This token can only be used for resending verification mails.
- A POST request can be made to `auth/resend` with the `Authorization` header set to the `resend-verification` token